### PR TITLE
Update hercjsu to return 0 when RC is 0000/0004

### DIFF
--- a/bin/hercjsu
+++ b/bin/hercjsu
@@ -173,7 +173,7 @@ sub do_file {
 
   my $fail = 0;
   foreach my $sdsc (@steps) {
-    $fail = 1 if $sdsc->{rcod} ne "RC= 0000" && $sdsc->{rcod} ne "RC= 0004";
+    $fail = 1 if $sdsc->{rcod} ne "0000" && $sdsc->{rcod} ne "0004";
   }
 
   close IFILE;


### PR DESCRIPTION
Script was always returning `2` when used on tk4 despite the RC being `0000`